### PR TITLE
New deployer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ docker build -t coco/coreos-registry-setup .
 # Set all the required variables
 TOKEN_URL=https://discovery.etcd.io/xxxxxx
 VAULT_PASS=xxxxxxxx
-DEPLOYER_SERVICE_FILE_LOCATION=https://raw.githubusercontent.com/Financial-Times/coco-docker-image-cache-services/master/service-files/deployer.service
+SERVICE_DEFINITION_LOCATION=https://raw.githubusercontent.com/Financial-Times/coco-docker-image-cache-services/master/services.yaml
 AWS_SECRET_ACCESS_KEY=xxxxxxx
 AWS_ACCESS_KEY_ID=xxxxxxxx
 
 # Run the image
-docker run --env "TOKEN_URL=$TOKEN_URL" --env "VAULT_PASS=$VAULT_PASS" --env "DEPLOYER_SERVICE_FILE_LOCATION=$DEPLOYER_SERVICE_FILE_LOCATION" --env "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" --env "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" coco/coreos-registry-setup
+docker run --env "TOKEN_URL=$TOKEN_URL" --env "VAULT_PASS=$VAULT_PASS" --env "SERVICE_DEFINITION_LOCATION=$SERVICE_DEFINITION_LOCATION" --env "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" --env "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" coco/coreos-registry-setup
 ```
 

--- a/ansible/userdata/default_instance_user_data.yaml
+++ b/ansible/userdata/default_instance_user_data.yaml
@@ -34,18 +34,48 @@ coreos:
           ExecStart=/bin/sh -c "etcdctl set /ft/_credentials/aws/aws_secret_access_key {{ aws_secret_access_key }};"
           ExecStart=/bin/sh -c "etcdctl set /ft/_credentials/elb_name coreos-registry-{{cp.msg}};"
           ExecStart=/bin/sh -c "etcdctl set /ft/_credentials/aws/s3_bucket com.ft.coco-docker-registry;"
-    - name: deploy-deployer.service
+          ExecStart=/bin/sh -c "etcdctl set /ft/config/service-definition-location '{{service_definition_location}}'"
+    - name: bootstrap.service
       command: start
       content: |
           [Unit]
-          Description=Deploy the deployer
+          Description=Start fleet services
           After=fleet.service
-
+          Requires=fleet.service
           [Service]
-          ExecStart=/bin/sh -c "curl {{deployer_service_file_location}} > /tmp/deployer.service; fleetctl start /tmp/deployer.service "
+          Type=oneshot
+          ExecStart=/bin/bash -c "fleetctl start /tmp/deployer.service"
+          ExecStart=/bin/bash -c "fleetctl start /tmp/deployer.timer"
 write_files:
   - path: /etc/systemd/system/fleet.socket.d/30-ListenStream.conf
     content: |
       [Socket]
       ListenStream=0.0.0.0:49153
+  - path: /tmp/deployer.service
+    content: |
+      [Unit]
+      Description=Deployer
+      After=docker.service
+      Requires=docker.service
+      [Service]
+      Environment="DOCKER_APP_VERSION=latest"
+      TimeoutStartSec=0
+      Type=oneshot
+      ExecStartPre=-/bin/bash -c '/usr/bin/docker kill %p > /dev/null 2>&1'
+      ExecStartPre=-/bin/bash -c '/usr/bin/docker rm %p > /dev/null 2>&1'
+      ExecStartPre=/bin/bash -c '/usr/bin/docker pull coco/coco-fleet-deployer:$DOCKER_APP_VERSION'
+      ExecStart=/bin/bash -c "SERVICE_DEFINITION_LOCATION=$(etcdctl get /ft/config/service-definition-location); docker run -v '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt' --rm --name %p --env=\"FLEET_ENDPOINT=http://$HOSTNAME:49153\" --env=\"SERVICES_DEFINITION_FILE_URI=$SERVICE_DEFINITION_LOCATION\" --env=\"DESTROY=true\" coco/coco-fleet-deployer:$DOCKER_APP_VERSION"
+  - path: /tmp/deployer.timer
+    content: |
+      [Unit]
+      Description=Deployer timer
+      
+      [Timer]
+      OnUnitActiveSec=1m
+      
+      [Install]
+      WantedBy=timers.target
+      
+      [X-Fleet]
+      MachineOf=deployer.service
 {% include 'ssh_authorized_keys.yaml' %}


### PR DESCRIPTION
NOTE: the ENV variable used in the splunk-forwarder is not passed (it is left empty), as probably there won't be multiple registries. 
The deployer service and timer unit file is now duplicated in both cloud configs (registry- and up-provisioner), we might want to extract them into a common file if we persist with our private registry.
